### PR TITLE
AES with very basic noise as side channel attack defense example

### DIFF
--- a/src/main/scala/aes/AES.scala
+++ b/src/main/scala/aes/AES.scala
@@ -6,7 +6,7 @@ import chisel3.util.Cat
 
 // implements wrapper for AES cipher and inverse cipher
 // change Nk=4 for AES128, NK=6 for AES192, Nk=8 for AES256
-class AES(Nk: Int) extends Module {
+class AES(Nk: Int, SubBytes_SCD: Boolean) extends Module {
   require(Nk == 4 || Nk == 6 || Nk == 8)
   val KeyLength: Int = Nk * Params.rows
   val Nr: Int = Nk + 6 // 10, 12, 14 rounds
@@ -24,7 +24,7 @@ class AES(Nk: Int) extends Module {
   })
 
   // Instantiate module objects
-  val CipherModule = Cipher(Nk)
+  val CipherModule = Cipher(Nk, SubBytes_SCD)
   val InvCipherModule = InvCipher(Nk)
 
   // Create a synchronous-read, synchronous-write memory block big enough for any key length
@@ -76,5 +76,5 @@ class AES(Nk: Int) extends Module {
 }
 
 object AES {
-  def apply(Nk: Int): AES = Module(new AES(Nk))
+  def apply(Nk: Int, SubBytes_SCD: Boolean): AES = Module(new AES(Nk, SubBytes_SCD))
 }

--- a/src/main/scala/aes/AES.scala
+++ b/src/main/scala/aes/AES.scala
@@ -6,7 +6,7 @@ import chisel3.util.Cat
 
 // implements wrapper for AES cipher and inverse cipher
 // change Nk=4 for AES128, NK=6 for AES192, Nk=8 for AES256
-class AES(Nk: Int, SubBytes_SCD: Boolean) extends Module {
+class AES(Nk: Int, SubBytes_SCD: Boolean, InvSubBytes_SCD: Boolean) extends Module {
   require(Nk == 4 || Nk == 6 || Nk == 8)
   val KeyLength: Int = Nk * Params.rows
   val Nr: Int = Nk + 6 // 10, 12, 14 rounds
@@ -25,7 +25,7 @@ class AES(Nk: Int, SubBytes_SCD: Boolean) extends Module {
 
   // Instantiate module objects
   val CipherModule = Cipher(Nk, SubBytes_SCD)
-  val InvCipherModule = InvCipher(Nk)
+  val InvCipherModule = InvCipher(Nk, InvSubBytes_SCD)
 
   // Create a synchronous-read, synchronous-write memory block big enough for any key length
   // A roundKey is Params.StateLength bytes, and 1+(10/12/14) (< EKDepth) of them are needed
@@ -76,5 +76,5 @@ class AES(Nk: Int, SubBytes_SCD: Boolean) extends Module {
 }
 
 object AES {
-  def apply(Nk: Int, SubBytes_SCD: Boolean): AES = Module(new AES(Nk, SubBytes_SCD))
+  def apply(Nk: Int, SubBytes_SCD: Boolean, InvSubBytes_SCD: Boolean): AES = Module(new AES(Nk, SubBytes_SCD, InvSubBytes_SCD))
 }

--- a/src/main/scala/aes/Cipher.scala
+++ b/src/main/scala/aes/Cipher.scala
@@ -5,7 +5,7 @@ import chisel3.util._
 
 // implements AES_Encrypt
 // change Nk=4 for AES128, NK=6 for AES192, Nk=8 for AES256
-class Cipher(Nk: Int) extends Module {
+class Cipher(Nk: Int, SubBytes_SCD: Boolean) extends Module {
   require(Nk == 4 || Nk == 6 || Nk == 8)
   val KeyLength: Int = Nk * Params.rows
   val Nr: Int = Nk + 6 // 10, 12, 14 rounds
@@ -21,7 +21,7 @@ class Cipher(Nk: Int) extends Module {
 
   // Instantiate module objects
   val AddRoundKeyModule = AddRoundKey()
-  val SubBytesModule = SubBytes()
+  val SubBytesModule = SubBytes(SubBytes_SCD)
   val ShiftRowsModule = ShiftRows()
   val MixColumnsModule = MixColumns()
 
@@ -82,5 +82,5 @@ class Cipher(Nk: Int) extends Module {
 }
 
 object Cipher {
-  def apply(Nk: Int): Cipher = Module(new Cipher(Nk))
+  def apply(Nk: Int, SubBytes_SCD: Boolean): Cipher = Module(new Cipher(Nk, SubBytes_SCD))
 }

--- a/src/main/scala/aes/InvCipher.scala
+++ b/src/main/scala/aes/InvCipher.scala
@@ -5,7 +5,7 @@ import chisel3.util._
 
 // implements AES_Decrypt
 // change Nk=4 for AES128, NK=6 for AES192, Nk=8 for AES256
-class InvCipher(Nk: Int) extends Module {
+class InvCipher(Nk: Int, InvSubBytes_SCD: Boolean) extends Module {
   require(Nk == 4 || Nk == 6 || Nk == 8)
   val KeyLength: Int = Nk * Params.rows
   val Nr: Int = Nk + 6 // 10, 12, 14 rounds
@@ -21,7 +21,7 @@ class InvCipher(Nk: Int) extends Module {
 
   // Instantiate module objects
   val AddRoundKeyModule = AddRoundKey()
-  val InvSubBytesModule = InvSubBytes()
+  val InvSubBytesModule = InvSubBytes(InvSubBytes_SCD)
   val InvShiftRowsModule = InvShiftRows()
   val InvMixColumnsModule = InvMixColumns()
 
@@ -81,5 +81,5 @@ class InvCipher(Nk: Int) extends Module {
 }
 
 object InvCipher {
-  def apply(Nk: Int): InvCipher = Module(new InvCipher(Nk))
+  def apply(Nk: Int, InvSubBytes_SCD: Boolean): InvCipher = Module(new InvCipher(Nk, InvSubBytes_SCD))
 }

--- a/src/main/scala/aes/InvSubBytes.scala
+++ b/src/main/scala/aes/InvSubBytes.scala
@@ -1,9 +1,11 @@
 package aes
 
 import chisel3._
+import chisel3.util._
+import lfsr.LFSR
 
 // implements InvSubBytes
-class InvSubBytes extends Module {
+class InvSubBytes(SCD: Boolean) extends Module {
   val io = IO(new Bundle {
     val state_in = Input(Vec(Params.StateLength, UInt(8.W)))
     val state_out = Output(Vec(Params.StateLength, UInt(8.W)))
@@ -30,8 +32,19 @@ class InvSubBytes extends Module {
   for (i <- 0 until Params.StateLength) {
     io.state_out(i) := inverted_s_box(io.state_in(i))
   }
+  if (SCD) {
+    // dummy noise module with LFSR
+    val LFSRModule = LFSR()
+    val lfsr6 = RegInit(0.U(6.W)) // 6 LFSR bits
+    lfsr6 := LFSRModule.io.lfsr_6
+    val lfsr3r = RegInit(0.U(3.W)) // 3 LFSR bits extracted
+    lfsr3r := LFSRModule.io.lfsr_3r
+    val inverted_s_box_lfsr = RegInit(0.U(8.W))
+    inverted_s_box_lfsr := inverted_s_box(Cat(lfsr6(4, 0), lfsr3r)) // 5 + 3 bits
+    printf("LFSR ISB %b %b %b %b %b \n", lfsr6, lfsr6(4, 0), lfsr3r, Cat(lfsr6(4, 0), lfsr3r), inverted_s_box_lfsr)
+  }
 }
 
 object InvSubBytes {
-  def apply(): InvSubBytes = Module(new InvSubBytes())
+  def apply(SCD: Boolean): InvSubBytes = Module(new InvSubBytes(SCD))
 }

--- a/src/main/scala/aes/SubBytes.scala
+++ b/src/main/scala/aes/SubBytes.scala
@@ -1,10 +1,11 @@
 package aes
 
 import chisel3._
+import chisel3.util._
 import lfsr.LFSR
 
 // implements SubBytes
-class SubBytes extends Module {
+class SubBytes(SCD: Boolean) extends Module {
   val io = IO(new Bundle {
     val state_in = Input(Vec(Params.StateLength, UInt(8.W)))
     val state_out = Output(Vec(Params.StateLength, UInt(8.W)))
@@ -32,13 +33,19 @@ class SubBytes extends Module {
     io.state_out(i) := s_box(io.state_in(i))
   }
 
-  val LFSRModule = LFSR()
-  val lfsr6 = RegInit(0.U(6.W))
-  lfsr6 := LFSRModule.io.lfsr_6
-  val lfsr3r = RegInit(0.U(3.W))
-  lfsr3r := LFSRModule.io.lfsr_3r
+  if (SCD) {
+    // dummy noise module with LFSR
+    val LFSRModule = LFSR()
+    val lfsr6 = RegInit(0.U(6.W)) // 6 LFSR bits
+    lfsr6 := LFSRModule.io.lfsr_6
+    val lfsr3r = RegInit(0.U(3.W)) // 3 LFSR bits extracted
+    lfsr3r := LFSRModule.io.lfsr_3r
+    val s_box_lfsr = RegInit(0.U(8.W))
+    s_box_lfsr := s_box(Cat(lfsr6(4, 0), lfsr3r)) // 5 + 3 bits
+    printf("%b %b %b %b %b \n", lfsr6, lfsr6(4, 0), lfsr3r, Cat(lfsr6(4, 0), lfsr3r), s_box_lfsr)
+  }
 }
 
 object SubBytes {
-  def apply(): SubBytes = Module(new SubBytes())
+  def apply(SCD: Boolean): SubBytes = Module(new SubBytes(SCD))
 }

--- a/src/main/scala/aes/SubBytes.scala
+++ b/src/main/scala/aes/SubBytes.scala
@@ -1,6 +1,7 @@
 package aes
 
 import chisel3._
+import lfsr.LFSR
 
 // implements SubBytes
 class SubBytes extends Module {
@@ -30,6 +31,12 @@ class SubBytes extends Module {
   for (i <- 0 until Params.StateLength) {
     io.state_out(i) := s_box(io.state_in(i))
   }
+
+  val LFSRModule = LFSR()
+  val lfsr6 = RegInit(0.U(6.W))
+  lfsr6 := LFSRModule.io.lfsr_6
+  val lfsr3r = RegInit(0.U(3.W))
+  lfsr3r := LFSRModule.io.lfsr_3r
 }
 
 object SubBytes {

--- a/src/main/scala/aes/SubBytes.scala
+++ b/src/main/scala/aes/SubBytes.scala
@@ -42,7 +42,7 @@ class SubBytes(SCD: Boolean) extends Module {
     lfsr3r := LFSRModule.io.lfsr_3r
     val s_box_lfsr = RegInit(0.U(8.W))
     s_box_lfsr := s_box(Cat(lfsr6(4, 0), lfsr3r)) // 5 + 3 bits
-    printf("%b %b %b %b %b \n", lfsr6, lfsr6(4, 0), lfsr3r, Cat(lfsr6(4, 0), lfsr3r), s_box_lfsr)
+    printf("LFSR  SB %b %b %b %b %b \n", lfsr6, lfsr6(4, 0), lfsr3r, Cat(lfsr6(4, 0), lfsr3r), s_box_lfsr)
   }
 }
 

--- a/src/main/scala/lfsr/LFSR.scala
+++ b/src/main/scala/lfsr/LFSR.scala
@@ -14,7 +14,7 @@ class LFSR extends Module {
   })
 
   //declare the 6-bit register and initialize to 000001
-  val D0123456 = Reg(init = UInt(1, 6)) //will init at reset
+  val D0123456 = RegInit(1.U(6.W)) //will init at reset
 
   //next clk value is XOR of 2 MSBs as LSB concatenated with left shift rest
   //example: 010010 => 100101 = Cat('10010','0^1')
@@ -27,4 +27,8 @@ class LFSR extends Module {
   io.lfsr_6 := D0123456
   //lfsr_3r in reverse order just for fun
   io.lfsr_3r := Cat(D0123456(1), D0123456(3), D0123456(5))
+}
+
+object LFSR {
+  def apply(): LFSR = Module(new LFSR())
 }

--- a/src/test/scala/aes/AESUnitTest.scala
+++ b/src/test/scala/aes/AESUnitTest.scala
@@ -3,7 +3,7 @@ package aes
 import chisel3.iotesters
 import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
 
-class AESUnitTester(c: AES, Nk: Int) extends PeekPokeTester(c) {
+class AESUnitTester(c: AES, Nk: Int, SubBytes_SCD: Boolean) extends PeekPokeTester(c) {
   require(Nk == 4 || Nk == 6 || Nk == 8)
 
   private val aes_i = c
@@ -154,25 +154,26 @@ class AESUnitTester(c: AES, Nk: Int) extends PeekPokeTester(c) {
 // sbt 'testOnly aes.AESTester -- -z vcd'
 
 class AESTester extends ChiselFlatSpec {
+  val SubBytes_SCD = true
   val Nk = 8 // 4, 6, 8 [32-bit words] columns in cipher key
   private val backendNames = Array[String]("firrtl", "verilator")
   for (backendName <- backendNames) {
     "AES" should s"execute cipher and inverse cipher (with $backendName)" in {
-      Driver(() => new AES(Nk), backendName) {
-        c => new AESUnitTester(c, Nk)
+      Driver(() => new AES(Nk, SubBytes_SCD), backendName) {
+        c => new AESUnitTester(c, Nk, SubBytes_SCD)
       } should be(true)
     }
   }
 
   "running with --is-verbose" should "show more about what's going on in the tester" in {
-    iotesters.Driver.execute(Array("--is-verbose"), () => new AES(Nk)) {
-      c => new AESUnitTester(c, Nk)
+    iotesters.Driver.execute(Array("--is-verbose"), () => new AES(Nk, SubBytes_SCD)) {
+      c => new AESUnitTester(c, Nk, SubBytes_SCD)
     } should be(true)
   }
 
   "running with --fint-write-vcd" should "create a vcd file from the test" in {
-    iotesters.Driver.execute(Array("--fint-write-vcd"), () => new AES(Nk)) {
-      c => new AESUnitTester(c, Nk)
+    iotesters.Driver.execute(Array("--fint-write-vcd"), () => new AES(Nk, SubBytes_SCD)) {
+      c => new AESUnitTester(c, Nk, SubBytes_SCD)
     } should be(true)
   }
 }

--- a/src/test/scala/aes/AESUnitTest.scala
+++ b/src/test/scala/aes/AESUnitTest.scala
@@ -3,7 +3,7 @@ package aes
 import chisel3.iotesters
 import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
 
-class AESUnitTester(c: AES, Nk: Int, SubBytes_SCD: Boolean) extends PeekPokeTester(c) {
+class AESUnitTester(c: AES, Nk: Int, SubBytes_SCD: Boolean, InvSubBytes_SCD: Boolean) extends PeekPokeTester(c) {
   require(Nk == 4 || Nk == 6 || Nk == 8)
 
   private val aes_i = c
@@ -155,25 +155,26 @@ class AESUnitTester(c: AES, Nk: Int, SubBytes_SCD: Boolean) extends PeekPokeTest
 
 class AESTester extends ChiselFlatSpec {
   val SubBytes_SCD = true
+  val InvSubBytes_SCD = true
   val Nk = 8 // 4, 6, 8 [32-bit words] columns in cipher key
   private val backendNames = Array[String]("firrtl", "verilator")
   for (backendName <- backendNames) {
     "AES" should s"execute cipher and inverse cipher (with $backendName)" in {
-      Driver(() => new AES(Nk, SubBytes_SCD), backendName) {
-        c => new AESUnitTester(c, Nk, SubBytes_SCD)
+      Driver(() => new AES(Nk, SubBytes_SCD, InvSubBytes_SCD), backendName) {
+        c => new AESUnitTester(c, Nk, SubBytes_SCD, InvSubBytes_SCD)
       } should be(true)
     }
   }
 
   "running with --is-verbose" should "show more about what's going on in the tester" in {
-    iotesters.Driver.execute(Array("--is-verbose"), () => new AES(Nk, SubBytes_SCD)) {
-      c => new AESUnitTester(c, Nk, SubBytes_SCD)
+    iotesters.Driver.execute(Array("--is-verbose"), () => new AES(Nk, SubBytes_SCD, InvSubBytes_SCD)) {
+      c => new AESUnitTester(c, Nk, SubBytes_SCD, InvSubBytes_SCD)
     } should be(true)
   }
 
   "running with --fint-write-vcd" should "create a vcd file from the test" in {
-    iotesters.Driver.execute(Array("--fint-write-vcd"), () => new AES(Nk, SubBytes_SCD)) {
-      c => new AESUnitTester(c, Nk, SubBytes_SCD)
+    iotesters.Driver.execute(Array("--fint-write-vcd"), () => new AES(Nk, SubBytes_SCD, InvSubBytes_SCD)) {
+      c => new AESUnitTester(c, Nk, SubBytes_SCD, InvSubBytes_SCD)
     } should be(true)
   }
 }

--- a/src/test/scala/aes/CipherUnitTest.scala
+++ b/src/test/scala/aes/CipherUnitTest.scala
@@ -3,7 +3,7 @@ package aes
 import chisel3.iotesters
 import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
 
-class CipherUnitTester(c: Cipher, Nk: Int) extends PeekPokeTester(c) {
+class CipherUnitTester(c: Cipher, Nk: Int, SubBytes_SCD: Boolean) extends PeekPokeTester(c) {
   require(Nk == 4 || Nk == 6 || Nk == 8)
 
   private val aes_cipher = c
@@ -122,24 +122,25 @@ class CipherUnitTester(c: Cipher, Nk: Int) extends PeekPokeTester(c) {
 
 class CipherTester extends ChiselFlatSpec {
   val Nk = 8 // 4, 6, 8 [32-bit words] columns in cipher key
+  val SubBytes_SCD = true
   private val backendNames = Array[String]("firrtl", "verilator")
   for (backendName <- backendNames) {
     "Cipher" should s"execute AES Cipher (with $backendName)" in {
-      Driver(() => new Cipher(Nk), backendName) {
-        c => new CipherUnitTester(c, Nk)
+      Driver(() => new Cipher(Nk, SubBytes_SCD), backendName) {
+        c => new CipherUnitTester(c, Nk, SubBytes_SCD)
       } should be(true)
     }
   }
 
   "running with --is-verbose" should "show more about what's going on in the tester" in {
-    iotesters.Driver.execute(Array("--is-verbose"), () => new Cipher(Nk)) {
-      c => new CipherUnitTester(c, Nk)
+    iotesters.Driver.execute(Array("--is-verbose"), () => new Cipher(Nk, SubBytes_SCD)) {
+      c => new CipherUnitTester(c, Nk, SubBytes_SCD)
     } should be(true)
   }
 
   "running with --fint-write-vcd" should "create a vcd file from the test" in {
-    iotesters.Driver.execute(Array("--fint-write-vcd"), () => new Cipher(Nk)) {
-      c => new CipherUnitTester(c, Nk)
+    iotesters.Driver.execute(Array("--fint-write-vcd"), () => new Cipher(Nk, SubBytes_SCD)) {
+      c => new CipherUnitTester(c, Nk, SubBytes_SCD)
     } should be(true)
   }
 }

--- a/src/test/scala/aes/InvCipherUnitTest.scala
+++ b/src/test/scala/aes/InvCipherUnitTest.scala
@@ -3,7 +3,7 @@ package aes
 import chisel3.iotesters
 import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
 
-class InvCipherUnitTester(c: InvCipher, Nk: Int) extends PeekPokeTester(c) {
+class InvCipherUnitTester(c: InvCipher, Nk: Int, InvSubBytes_SCD: Boolean) extends PeekPokeTester(c) {
   require(Nk == 4 || Nk == 6 || Nk == 8)
 
   private val aes_icipher = c
@@ -120,25 +120,26 @@ class InvCipherUnitTester(c: InvCipher, Nk: Int) extends PeekPokeTester(c) {
 // extend with the option '-- -z verbose' or '-- -z vcd' for specific test
 
 class InvCipherTester extends ChiselFlatSpec {
+  val InvSubBytes_SCD = true
   val Nk = 8 // 4, 6, 8 [32-bit words] columns in cipher key
   private val backendNames = Array[String]("firrtl", "verilator")
   for (backendName <- backendNames) {
     "Inverse Cipher" should s"execute AES Inverse Cipher (with $backendName)" in {
-      Driver(() => new InvCipher(Nk), backendName) {
-        c => new InvCipherUnitTester(c, Nk)
+      Driver(() => new InvCipher(Nk, InvSubBytes_SCD), backendName) {
+        c => new InvCipherUnitTester(c, Nk, InvSubBytes_SCD)
       } should be(true)
     }
   }
 
   "running with --is-verbose" should "show more about what's going on in the tester" in {
-    iotesters.Driver.execute(Array("--is-verbose"), () => new InvCipher(Nk)) {
-      c => new InvCipherUnitTester(c, Nk)
+    iotesters.Driver.execute(Array("--is-verbose"), () => new InvCipher(Nk, InvSubBytes_SCD)) {
+      c => new InvCipherUnitTester(c, Nk, InvSubBytes_SCD)
     } should be(true)
   }
 
   "running with --fint-write-vcd" should "create a vcd file from the test" in {
-    iotesters.Driver.execute(Array("--fint-write-vcd"), () => new InvCipher(Nk)) {
-      c => new InvCipherUnitTester(c, Nk)
+    iotesters.Driver.execute(Array("--fint-write-vcd"), () => new InvCipher(Nk, InvSubBytes_SCD)) {
+      c => new InvCipherUnitTester(c, Nk, InvSubBytes_SCD)
     } should be(true)
   }
 }

--- a/src/test/scala/aes/InvSubBytesUnitTest.scala
+++ b/src/test/scala/aes/InvSubBytesUnitTest.scala
@@ -3,7 +3,7 @@ package aes
 import chisel3.iotesters
 import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
 
-class InvSubBytesUnitTester(c: InvSubBytes) extends PeekPokeTester(c) {
+class InvSubBytesUnitTester(c: InvSubBytes, SCD: Boolean) extends PeekPokeTester(c) {
 
   def computeInvSubBytes(state_in: Array[Int]): Array[Int] = {
     var inverted_s_box = Array(
@@ -44,6 +44,8 @@ class InvSubBytesUnitTester(c: InvSubBytes) extends PeekPokeTester(c) {
 
   for (i <- 0 until Params.StateLength)
     expect(aes_isb.io.state_out(i), state(i))
+
+  step(20)
 }
 
 // Run test with:
@@ -51,24 +53,25 @@ class InvSubBytesUnitTester(c: InvSubBytes) extends PeekPokeTester(c) {
 // extend with the option '-- -z verbose' or '-- -z vcd' for specific test
 
 class InvSubBytesTester extends ChiselFlatSpec {
+  val SCD = true
   private val backendNames = Array[String]("firrtl", "verilator")
   for (backendName <- backendNames) {
     "InvSubBytes" should s"execute AES InvSubBytes (with $backendName)" in {
-      Driver(() => new InvSubBytes, backendName) {
-        c => new InvSubBytesUnitTester(c)
+      Driver(() => new InvSubBytes(SCD), backendName) {
+        c => new InvSubBytesUnitTester(c, SCD)
       } should be(true)
     }
   }
 
   "running with --is-verbose" should "show more about what's going on in the tester" in {
-    iotesters.Driver.execute(Array("--is-verbose"), () => new InvSubBytes) {
-      c => new InvSubBytesUnitTester(c)
+    iotesters.Driver.execute(Array("--is-verbose"), () => new InvSubBytes(SCD)) {
+      c => new InvSubBytesUnitTester(c, SCD)
     } should be(true)
   }
 
   "running with --fint-write-vcd" should "create a vcd file from the test" in {
-    iotesters.Driver.execute(Array("--fint-write-vcd"), () => new InvSubBytes) {
-      c => new InvSubBytesUnitTester(c)
+    iotesters.Driver.execute(Array("--fint-write-vcd"), () => new InvSubBytes(SCD)) {
+      c => new InvSubBytesUnitTester(c, SCD)
     } should be(true)
   }
 }

--- a/src/test/scala/aes/SubBytesUnitTest.scala
+++ b/src/test/scala/aes/SubBytesUnitTest.scala
@@ -2,8 +2,9 @@ package aes
 
 import chisel3.iotesters
 import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
+import org.scalacheck.Prop.True
 
-class SubBytesUnitTester(c: SubBytes) extends PeekPokeTester(c) {
+class SubBytesUnitTester(c: SubBytes, SCD: Boolean) extends PeekPokeTester(c) {
 
   def computeSubBytes(state_in: Array[Int]): Array[Int] = {
     var s_box = Array(
@@ -45,7 +46,7 @@ class SubBytesUnitTester(c: SubBytes) extends PeekPokeTester(c) {
   for (i <- 0 until Params.StateLength)
     expect(aes_sb.io.state_out(i), state(i))
 
-  step(100)
+  step(20)
 }
 
 // Run test with:
@@ -53,24 +54,25 @@ class SubBytesUnitTester(c: SubBytes) extends PeekPokeTester(c) {
 // extend with the option '-- -z verbose' or '-- -z vcd' for specific test
 
 class SubBytesTester extends ChiselFlatSpec {
+  val SCD = true
   private val backendNames = Array[String]("firrtl", "verilator")
   for (backendName <- backendNames) {
     "SubBytes" should s"execute AES SubBytes (with $backendName)" in {
-      Driver(() => new SubBytes, backendName) {
-        c => new SubBytesUnitTester(c)
+      Driver(() => new SubBytes(SCD), backendName) {
+        c => new SubBytesUnitTester(c, SCD)
       } should be(true)
     }
   }
 
   "running with --is-verbose" should "show more about what's going on in the tester" in {
-    iotesters.Driver.execute(Array("--is-verbose"), () => new SubBytes) {
-      c => new SubBytesUnitTester(c)
+    iotesters.Driver.execute(Array("--is-verbose"), () => new SubBytes(SCD)) {
+      c => new SubBytesUnitTester(c, SCD)
     } should be(true)
   }
 
   "running with --fint-write-vcd" should "create a vcd file from the test" in {
-    iotesters.Driver.execute(Array("--fint-write-vcd"), () => new SubBytes) {
-      c => new SubBytesUnitTester(c)
+    iotesters.Driver.execute(Array("--fint-write-vcd"), () => new SubBytes(SCD)) {
+      c => new SubBytesUnitTester(c, SCD)
     } should be(true)
   }
 }

--- a/src/test/scala/aes/SubBytesUnitTest.scala
+++ b/src/test/scala/aes/SubBytesUnitTest.scala
@@ -2,7 +2,6 @@ package aes
 
 import chisel3.iotesters
 import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
-import org.scalacheck.Prop.True
 
 class SubBytesUnitTester(c: SubBytes, SCD: Boolean) extends PeekPokeTester(c) {
 

--- a/src/test/scala/aes/SubBytesUnitTest.scala
+++ b/src/test/scala/aes/SubBytesUnitTest.scala
@@ -44,6 +44,8 @@ class SubBytesUnitTester(c: SubBytes) extends PeekPokeTester(c) {
 
   for (i <- 0 until Params.StateLength)
     expect(aes_sb.io.state_out(i), state(i))
+
+  step(100)
 }
 
 // Run test with:


### PR DESCRIPTION
I added an LFSR-6 inside the SubBytes and InvSubBytes each read s_box and inverted_s_box in each. The components are optional and can be enabled by setting either (or both) SubBytes_SCD and InvSubBytes_SCD to true.